### PR TITLE
소비내역 확인 버튼 추가 및 챗봇 기능 개선

### DIFF
--- a/frontend-main/src/chat/VoiceChat.css
+++ b/frontend-main/src/chat/VoiceChat.css
@@ -48,6 +48,30 @@
   transform: translateX(-50%);
 }
 
+/* 소비내역 보기 버튼 스타일 */
+.consumption-btn {
+  margin-bottom: 20px;
+  padding: 15px;
+  font-size: 18px;
+  border: none;
+  border-radius: 10px;
+  background-color: #4ECDC4;
+  color: #fff;
+  position: fixed;
+  font-weight: bold;
+  width: 300px;
+  bottom: 90px;
+  left: 50%;
+  transform: translateX(-50%);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+}
+
+.consumption-btn:hover {
+  background-color: #3db1a8;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+
 .textbox {
   font-family: 'Pretendard', sans-serif;
   width: 330px;

--- a/frontend-main/src/chat/VoiceChat.js
+++ b/frontend-main/src/chat/VoiceChat.js
@@ -114,6 +114,11 @@ function VoiceChat(props) {
       endRecord();
   };
 
+  // 소비내역 페이지로 이동하는 함수
+  const goToConsumptionPage = () => {
+    navi("/consumption");
+  };
+
   return (
     <div className="voicechat-section">
       <VoiceHeader />
@@ -126,6 +131,11 @@ function VoiceChat(props) {
       </button>
       <button className="chat-startBtn" onClick={handleStartChat}>
         {isStart ? "중지" : "똑똑!"}
+      </button>
+
+      {/* 소비내역 보기 버튼 */}
+      <button className="consumption-btn" onClick={goToConsumptionPage}>
+        💰 소비내역 보기
       </button>
 
       {/* Modal 컴포넌트 */}

--- a/frontend-main/src/consume/Consumption.css
+++ b/frontend-main/src/consume/Consumption.css
@@ -23,12 +23,57 @@
   line-height: 1.5;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   animation: pulse 2s infinite;
+  position: relative;
 }
 
 @keyframes pulse {
   0% { transform: scale(1); }
   50% { transform: scale(1.02); }
   100% { transform: scale(1); }
+}
+
+/* 음성 채팅으로 가기 버튼 */
+.go-to-chat-btn {
+  margin-top: 15px;
+  padding: 10px 20px;
+  background-color: #FF961B;
+  color: white;
+  border: none;
+  border-radius: 25px;
+  font-weight: bold;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  display: inline-block;
+}
+
+.go-to-chat-btn:hover {
+  background-color: #ff8600;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+}
+
+/* 음성 채팅으로 가기 - 큰 버튼 (내역 없을 때) */
+.go-to-chat-btn-large {
+  margin-top: 25px;
+  padding: 15px 30px;
+  background-color: #FF961B;
+  color: white;
+  border: none;
+  border-radius: 30px;
+  font-weight: bold;
+  font-size: 18px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  display: inline-block;
+}
+
+.go-to-chat-btn-large:hover {
+  background-color: #ff8600;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
 }
 
 /* 차트 섹션 */
@@ -145,6 +190,40 @@
   margin: 0;
 }
 
+/* 에러 컨테이너 */
+.error-container {
+  text-align: center;
+  padding: 40px 20px;
+  background: #fff5f5;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  margin: 20px 0;
+  border: 1px solid #ffcccc;
+}
+
+.error-text {
+  font-size: 18px;
+  color: #e74c3c;
+  margin-bottom: 20px;
+}
+
+.retry-button {
+  padding: 10px 25px;
+  background-color: #e74c3c;
+  color: white;
+  border: none;
+  border-radius: 25px;
+  font-weight: bold;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.retry-button:hover {
+  background-color: #c0392b;
+  transform: translateY(-2px);
+}
+
 /* 데이터 없음 컨테이너 */
 .no-data-container {
   text-align: center;
@@ -214,6 +293,12 @@
   .category-filter-button {
     padding: 8px 16px;
     font-size: 13px;
+  }
+  
+  .go-to-chat-btn, 
+  .go-to-chat-btn-large {
+    padding: 10px 20px;
+    font-size: 14px;
   }
 }
 


### PR DESCRIPTION
## 문제 해결

이 PR은 다음 문제를 해결합니다:

1. 소비내역을 볼 수 있는 버튼이 보이지 않는 문제
2. 챗봇이 "5000원 썼다"와 같은 간단한 소비 메시지에 응답하지 않는 문제
3. API 경로 불일치로 인한 연결 문제

## 변경 사항

### 1. 소비내역 확인 버튼 추가
- 채팅 화면에 "소비내역 보기" 버튼 추가
- 음성 채팅 화면에서 소비내역 페이지로 직접 이동할 수 있는 기능 추가
- 버튼 스타일링 및 위치 조정

### 2. 소비내역 화면 개선
- 소비내역 페이지에서 다시 음성 채팅으로 돌아갈 수 있는 버튼 추가
- 내역이 없을 때 음성 채팅으로 가는 버튼 추가
- 에러 처리 및 재시도 기능 추가

### 3. 소비내역 파싱 개선
- 간단한 "5000원 썼다"와 같은 메시지도 자동으로 인식하도록 개선
- 소비 관련 키워드 목록 확장
- 디버그 로깅 강화

### 4. API 경로 수정
- 올바른 API 경로로 수정 (`/api/v1/consumption`)
- 소비내역 저장 시 네트워크 오류 처리 강화

## 테스트 방법
1. 챗봇 화면에서 "소비내역 보기" 버튼 클릭하여 소비내역 페이지로 이동
2. 챗봇에 "5000원 썼다"라고 말해보기
3. 챗봇의 응답 확인 및 소비내역 페이지에서 기록 확인